### PR TITLE
write_image refuses to write .nii.gz

### DIFF
--- a/fexp/writers.py
+++ b/fexp/writers.py
@@ -52,9 +52,9 @@ def write_image(data, filepath, compression=True, metadata=None, resample=False)
         if 'direction' in metadata:
             sitk_image.SetDirection(metadata['direction'])
 
-    if any([_ in filepath.suffix for _ in possible_exts]):
+    if any([str(filepath).endswith(ext) for ext in possible_exts]):
         try:
-            sitk.WriteImage(sitk_image, str(filepath), True if filepath.suffix == 'nii.gz' else compression)
+            sitk.WriteImage(sitk_image, str(filepath), True if str(filepath).endswith('.nii.gz') else compression)
         except RuntimeError as e:
             error_str = str(e)
             if error_str.startswith('Exception thrown in SimpleITK WriteImage'):


### PR DESCRIPTION
pathlib's [`suffix`](https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.suffix) only gives you the last extension, so for `image.nii.gz` you would only get the suffix `".gz"`.

The combination of `str` and `endswith` is not very elegant, but is the simplest solution. You could also use [`suffixes`](https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.suffixes) to get a list of all extensions, so `["nii", "gz"]` in this case, but then you're stuck with a list.